### PR TITLE
Updated API URL

### DIFF
--- a/src/util/api.ts
+++ b/src/util/api.ts
@@ -8,7 +8,7 @@ import {
 
 const fetch = require("node-fetch");
 
-const API_URL = "https://app-api.8slp.net/v1";
+const API_URL = "https://client-api.8slp.net/v1";
 
 async function api<T>({
   method = "GET",


### PR DESCRIPTION
This plugin was failing to login to the Eight Sleep API, so did a little digging and noticed the API URL was changed at some point. Seems to be working well now with a change to 'client-api' instead of 'app-api'.